### PR TITLE
修正: TollFree の電話番号に Bundle が紐づけできていない

### DIFF
--- a/assign.js
+++ b/assign.js
@@ -73,7 +73,7 @@ const setBundle = async (twilioClient, bundles) => {
                 }
               });
           }
-          if (regulation.numberType === "toll_free") {
+          if (regulation.numberType === "toll-free") {
             tollFreeBundleSid = bundle.sid;
             await twilioClient.numbers.v2.regulatoryCompliance
               .bundles(bundle.sid)


### PR DESCRIPTION
自分の環境に存在する Bundle から `Regulation#numberType` をリストアップしてみた所、TollFree 番号の場合の識別子は `toll_free` ではなく `toll-free` となっていそうでした。

<img width="980" alt="regulation_number_type" src="https://github.com/mobilebiz/assign-bundle-to-number/assets/1795793/7e254a26-4488-457b-9a72-2abe13423230">

Bundle を電話番号種別ごとに絞り込む際、TollFree の Bundle を `toll_free` で探索していたため Bundle が発見できず、電話番号にも紐づけできていなかったようですので、修正を作成してみました。